### PR TITLE
misspell - stdout.log -> stdout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Examples
     logger.error('error message')
     logger.critical('critical message')
 
-    # Prints the following to `stdout.log` (all messages at level `INFO` or below):
+    # Prints the following to `stdout` (all messages at level `INFO` or below):
 
     debug message
     info message


### PR DESCRIPTION
Prints the following to `stdout.log` (all messages at level `INFO` or below):
-->  # Prints the following to `stdout` (all messages at level `INFO` or below):